### PR TITLE
Bring back support to laravel 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 composer.lock
 phpmd.xml

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,10 @@
         }
     ],
     "require": {
-        "illuminate/auth": "^7.0",
-        "illuminate/database": "^7.0",
-        "illuminate/support": "^7.0",
+        "php": "^7.2",
+        "illuminate/auth": "^6.0|^7.0",
+        "illuminate/database": "^6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0",
         "laravel/socialite": "^4.2"
     },
     "require-dev": {


### PR DESCRIPTION
The previous [commit](https://github.com/GeneaLabs/laravel-socialiter/commit/ef51cfba55adfa30f2b2a0052ad4530fcf33ed89) that adds support to laravel 7.0 removed the support for 6.0. This PR is to make this package compatible to 6.0 again.