### PR TITLE
✨ feat(auth): add custom user-creation callback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,46 @@ We thank the following sponsors for their generosity, please take a moment to ch
     }
     ```
 
+<a name="CustomRegistration"></a>
+
+## Custom Registration
+
+By default, Socialiter creates new users with just their `name`, `email`, and a
+random password. If you need to customize how users are created (for example, to
+set additional attributes or use a custom creation flow), register a callback in
+your `AppServiceProvider`:
+
+```php
+use GeneaLabs\LaravelSocialiter\Socialiter;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Socialiter::createUsersUsing(function (SocialiteUser $socialiteUser) {
+            return \App\Models\User::create([
+                'name' => $socialiteUser->getName(),
+                'email' => $socialiteUser->getEmail(),
+                'password' => \Illuminate\Support\Str::random(64),
+                'avatar' => $socialiteUser->getAvatar(),
+                'locale' => 'en',
+                // ... any additional attributes
+            ]);
+        });
+    }
+}
+```
+
+The callback receives the raw Socialite user object and must return a persisted
+`User` model instance. If no callback is registered, the default behavior is
+used. You can reset to default at any time with
+`Socialiter::createUsersUsingDefault()`.
+
+> **Note:** The custom callback is only invoked when creating a *new* user. If
+> an existing user with the same email is found, Socialiter links the social
+> credentials to that user without invoking the callback.
+
 <a name="Implementation"></a>
 
 ## Implementation

--- a/src/Socialiter.php
+++ b/src/Socialiter.php
@@ -12,6 +12,9 @@ class Socialiter
 {
     public static $runsMigrations = true;
 
+    /** @var callable|null */
+    protected static $userCreator = null;
+
     protected $isStateless = false;
     protected $config;
     protected $driver;
@@ -20,6 +23,27 @@ class Socialiter
     public static function ignoreMigrations(): void
     {
         static::$runsMigrations = false;
+    }
+
+    /**
+     * Register a custom user-creation callback.
+     *
+     * The callback receives the Socialite user and should return an
+     * Eloquent User model instance (persisted).
+     *
+     * @param  callable(AbstractUser): Model  $callback
+     */
+    public static function createUsersUsing(callable $callback): void
+    {
+        static::$userCreator = $callback;
+    }
+
+    /**
+     * Reset the custom user-creation callback to the default behavior.
+     */
+    public static function createUsersUsingDefault(): void
+    {
+        static::$userCreator = null;
     }
 
     public function driver(string $driver): self
@@ -81,6 +105,10 @@ class Socialiter
 
         if ($user) {
             return $user;
+        }
+
+        if (static::$userCreator) {
+            return call_user_func(static::$userCreator, $socialiteUser);
         }
 
         return (new $userClass)->create([

--- a/src/Socialiter.php
+++ b/src/Socialiter.php
@@ -12,7 +12,6 @@ class Socialiter
 {
     public static $runsMigrations = true;
 
-    /** @var callable|null */
     protected static $userCreator = null;
 
     protected $isStateless = false;
@@ -25,22 +24,11 @@ class Socialiter
         static::$runsMigrations = false;
     }
 
-    /**
-     * Register a custom user-creation callback.
-     *
-     * The callback receives the Socialite user and should return an
-     * Eloquent User model instance (persisted).
-     *
-     * @param  callable(AbstractUser): Model  $callback
-     */
     public static function createUsersUsing(callable $callback): void
     {
         static::$userCreator = $callback;
     }
 
-    /**
-     * Reset the custom user-creation callback to the default behavior.
-     */
     public static function createUsersUsingDefault(): void
     {
         static::$userCreator = null;
@@ -108,7 +96,13 @@ class Socialiter
         }
 
         if (static::$userCreator) {
-            return call_user_func(static::$userCreator, $socialiteUser);
+            $user = call_user_func(static::$userCreator, $socialiteUser);
+
+            if (! $user instanceof Model || ! $user->exists) {
+                throw new \RuntimeException('The custom user creator must return a persisted User model.');
+            }
+
+            return $user;
         }
 
         return (new $userClass)->create([

--- a/tests/CustomRegistrationTest.php
+++ b/tests/CustomRegistrationTest.php
@@ -1,0 +1,207 @@
+<?php
+
+use GeneaLabs\LaravelSocialiter\SocialCredentials;
+use GeneaLabs\LaravelSocialiter\Socialiter;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Str;
+use Laravel\Socialite\Two\User as SocialiteUser;
+
+beforeEach(function () {
+    config(['auth.providers.users.model' => CustomTestUser::class]);
+    Socialiter::createUsersUsingDefault();
+
+    // Add custom_field column to users table for testing
+    if (! \Illuminate\Support\Facades\Schema::hasColumn('users', 'custom_field')) {
+        \Illuminate\Support\Facades\Schema::table('users', function ($table) {
+            $table->string('custom_field')->nullable();
+        });
+    }
+});
+
+function makeCustomSocialiteUser(array $overrides = []): SocialiteUser
+{
+    $user = new SocialiteUser;
+    $user->id = $overrides['id'] ?? 'custom-provider-123';
+    $user->name = $overrides['name'] ?? 'Custom User';
+    $user->email = $overrides['email'] ?? 'custom@example.com';
+    $user->token = $overrides['token'] ?? 'access-token-custom';
+    $user->refreshToken = $overrides['refreshToken'] ?? 'refresh-token-custom';
+    $user->expiresIn = $overrides['expiresIn'] ?? 3600;
+    $user->avatar = $overrides['avatar'] ?? 'https://example.com/custom-avatar.jpg';
+    $user->nickname = $overrides['nickname'] ?? 'customuser';
+
+    return $user;
+}
+
+it('uses a custom user-creation callback when registered', function () {
+    Socialiter::createUsersUsing(function (SocialiteUser $socialiteUser) {
+        return CustomTestUser::create([
+            'name' => $socialiteUser->getName(),
+            'email' => $socialiteUser->getEmail(),
+            'password' => 'custom-password',
+            'custom_field' => 'custom-value',
+        ]);
+    });
+
+    $socialiteUser = makeCustomSocialiteUser([
+        'email' => 'callback@example.com',
+        'name' => 'Callback User',
+    ]);
+
+    $socialiter = new Socialiter;
+    $reflection = new ReflectionClass($socialiter);
+
+    $driverProp = $reflection->getProperty('driver');
+    $driverProp->setAccessible(true);
+    $driverProp->setValue($socialiter, 'google');
+
+    $method = $reflection->getMethod('createCredentials');
+    $method->setAccessible(true);
+    $credential = $method->invoke($socialiter, $socialiteUser);
+
+    $user = CustomTestUser::where('email', 'callback@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->name)->toBe('Callback User')
+        ->and($user->custom_field)->toBe('custom-value')
+        ->and($user->password)->toBe('custom-password')
+        ->and($credential->user_id)->toBe($user->id);
+});
+
+it('falls back to default user creation when no callback is registered', function () {
+    $socialiteUser = makeCustomSocialiteUser([
+        'email' => 'default@example.com',
+        'name' => 'Default User',
+    ]);
+
+    $socialiter = new Socialiter;
+    $reflection = new ReflectionClass($socialiter);
+
+    $driverProp = $reflection->getProperty('driver');
+    $driverProp->setAccessible(true);
+    $driverProp->setValue($socialiter, 'github');
+
+    $method = $reflection->getMethod('createCredentials');
+    $method->setAccessible(true);
+    $credential = $method->invoke($socialiter, $socialiteUser);
+
+    $user = CustomTestUser::where('email', 'default@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->name)->toBe('Default User')
+        ->and($user->custom_field)->toBeNull()
+        ->and($credential->user_id)->toBe($user->id);
+});
+
+it('returns a valid persisted user model from the custom callback', function () {
+    Socialiter::createUsersUsing(function (SocialiteUser $socialiteUser) {
+        return CustomTestUser::create([
+            'name' => $socialiteUser->getName(),
+            'email' => $socialiteUser->getEmail(),
+            'password' => Str::random(64),
+            'custom_field' => 'persisted',
+        ]);
+    });
+
+    $socialiteUser = makeCustomSocialiteUser([
+        'email' => 'persisted@example.com',
+        'name' => 'Persisted User',
+    ]);
+
+    $socialiter = new Socialiter;
+    $reflection = new ReflectionClass($socialiter);
+
+    $driverProp = $reflection->getProperty('driver');
+    $driverProp->setAccessible(true);
+    $driverProp->setValue($socialiter, 'google');
+
+    $method = $reflection->getMethod('createCredentials');
+    $method->setAccessible(true);
+    $credential = $method->invoke($socialiter, $socialiteUser);
+
+    $user = $credential->user;
+
+    expect($user)->toBeInstanceOf(CustomTestUser::class)
+        ->and($user->exists)->toBeTrue()
+        ->and($user->id)->not->toBeNull()
+        ->and($user->email)->toBe('persisted@example.com')
+        ->and($user->custom_field)->toBe('persisted');
+});
+
+it('still finds existing user by email even with custom callback registered', function () {
+    Socialiter::createUsersUsing(function (SocialiteUser $socialiteUser) {
+        return CustomTestUser::create([
+            'name' => $socialiteUser->getName(),
+            'email' => $socialiteUser->getEmail(),
+            'password' => 'should-not-be-called',
+            'custom_field' => 'should-not-exist',
+        ]);
+    });
+
+    $existingUser = CustomTestUser::create([
+        'name' => 'Existing',
+        'email' => 'exists@example.com',
+        'password' => 'original',
+    ]);
+
+    $socialiteUser = makeCustomSocialiteUser([
+        'email' => 'exists@example.com',
+        'id' => 'provider-existing',
+    ]);
+
+    $socialiter = new Socialiter;
+    $reflection = new ReflectionClass($socialiter);
+
+    $driverProp = $reflection->getProperty('driver');
+    $driverProp->setAccessible(true);
+    $driverProp->setValue($socialiter, 'google');
+
+    $method = $reflection->getMethod('createCredentials');
+    $method->setAccessible(true);
+    $credential = $method->invoke($socialiter, $socialiteUser);
+
+    expect($credential->user_id)->toBe($existingUser->id)
+        ->and(CustomTestUser::count())->toBe(1)
+        ->and($existingUser->fresh()->password)->toBe('original');
+});
+
+it('resets to default behavior after calling createUsersUsingDefault', function () {
+    Socialiter::createUsersUsing(function (SocialiteUser $socialiteUser) {
+        return CustomTestUser::create([
+            'name' => $socialiteUser->getName(),
+            'email' => $socialiteUser->getEmail(),
+            'password' => 'custom',
+            'custom_field' => 'was-custom',
+        ]);
+    });
+
+    Socialiter::createUsersUsingDefault();
+
+    $socialiteUser = makeCustomSocialiteUser([
+        'email' => 'reset@example.com',
+        'name' => 'Reset User',
+    ]);
+
+    $socialiter = new Socialiter;
+    $reflection = new ReflectionClass($socialiter);
+
+    $driverProp = $reflection->getProperty('driver');
+    $driverProp->setAccessible(true);
+    $driverProp->setValue($socialiter, 'google');
+
+    $method = $reflection->getMethod('createCredentials');
+    $method->setAccessible(true);
+    $credential = $method->invoke($socialiter, $socialiteUser);
+
+    $user = CustomTestUser::where('email', 'reset@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->custom_field)->toBeNull();
+});
+
+// Test model with custom field
+class CustomTestUser extends Authenticatable
+{
+    protected $table = 'users';
+    protected $guarded = [];
+}

--- a/tests/CustomRegistrationTest.php
+++ b/tests/CustomRegistrationTest.php
@@ -18,6 +18,10 @@ beforeEach(function () {
     }
 });
 
+afterEach(function () {
+    Socialiter::createUsersUsingDefault();
+});
+
 function makeCustomSocialiteUser(array $overrides = []): SocialiteUser
 {
     $user = new SocialiteUser;


### PR DESCRIPTION
## Summary

Add support for custom user-creation logic when Socialiter registers a new social user, allowing developers to define additional attributes or custom persistence logic via `Socialiter::createUsersUsing()`.

## Changes

- Added `Socialiter::createUsersUsing(callable $callback)` static method to register a custom user-creation callback
- Added `Socialiter::createUsersUsingDefault()` to reset to default behavior
- Modified `createUser()` to invoke the custom callback when set, falling back to the default behavior otherwise
- Existing user lookup by email still takes priority — the callback is only invoked for genuinely new users
- Updated README with a "Custom Registration" section and usage example
- Added 5 new tests covering all callback scenarios

## Acceptance Criteria

- [x] Developers can register a custom user-creation callback or class that Socialiter invokes when registering a new social user
- [x] Custom callback/class receives the raw social user data (`Laravel\Socialite\Contracts\User`) and can return a fully populated `User` model
- [x] If no custom callback is registered, the default Socialiter user-creation behavior is preserved
- [x] Custom callback is configurable via service provider binding or config option
- [x] README updated with a usage example showing custom registration logic
- [x] Tests cover: custom callback invocation, default fallback when no callback registered, returned user model validity

## Test Coverage

- `it uses a custom user-creation callback when registered` — verifies custom callback is invoked and custom fields are set
- `it falls back to default user creation when no callback is registered` — verifies default behavior preserved
- `it returns a valid persisted user model from the custom callback` — verifies the returned model exists in DB
- `it still finds existing user by email even with custom callback registered` — verifies email lookup takes priority
- `it resets to default behavior after calling createUsersUsingDefault` — verifies reset mechanism

Fixes #3